### PR TITLE
🐛 Remove the short option from `pretty` and `profile`

### DIFF
--- a/catastrophicc/src/args/mod.rs
+++ b/catastrophicc/src/args/mod.rs
@@ -10,10 +10,10 @@ pub struct Args {
     #[arg(long)]
     pub debug: Option<flags::DebugMode>,
 
-    #[arg(short, long)]
+    #[arg(long)]
     pub pretty: bool,
 
-    #[arg(short, long)]
+    #[arg(long)]
     pub profile: bool,
 
     #[arg(long = "opt", default_value = "all")]


### PR DESCRIPTION
This fixes #10 by removing the clashing short options - neither of these are important enough to reserve an entire letter to themselves, so I remove them both